### PR TITLE
Set up endpoint for booking sessions.

### DIFF
--- a/controllers/sessionController.js
+++ b/controllers/sessionController.js
@@ -1,11 +1,18 @@
 import Session from "../models/Session.js";
 
 export const createSession = async (req, res) => {
-  const { userId, name, startTime, duration } = req.body;
+  //duration in minutes
+  const { userId, name, startTime, duration, sessionType } = req.body;
 
   if (!startTime || !duration) {
     return res.status(400).json({
       message: "Both startTime and duration are required",
+    });
+  }
+
+  if (!name || !sessionType) {
+    return res.status(400).json({
+      message: "Both name and sessionType are required",
     });
   }
 
@@ -14,12 +21,28 @@ export const createSession = async (req, res) => {
 
     const endDate = new Date(startDate.getTime() + duration * 60000);
 
+    const overlaps = await Session.find({
+      $or: [
+        { startTime: { $lt: startDate }, endTime: { $gt: startDate } },
+        { startTime: { $lt: endDate }, endTime: { $gt: endDate } },
+        { startTime: { $gt: startDate }, endTime: { $lt: endDate } }
+      ],
+      status: "scheduled"
+    });
+    if (overlaps.length != 0) {
+      return res.status(400).json({
+        message: "The session's schedule time is clashing with another session timing's.",
+      });
+    }
+
     const newSession = new Session({
       userId,
-      name,
+      sessionName: name,
       startTime: startDate,
       endTime: endDate,
-      duration: duration, // Minutes
+      duration: duration, //why save it when we have start and end time ??
+      status: "scheduled",
+      sessionType: sessionType
     });
 
     await newSession.save();
@@ -39,6 +62,19 @@ export const createSession = async (req, res) => {
 export const rescheduleSession = async (req, res) => {
   const { id } = req.params;
   const { startTime, duration } = req.body;
+  
+  if (!id) {
+    return res.status(400).json({
+      message: "Session Id is required",
+    });
+  }
+
+  if (!startTime || !duration) {
+    return res.status(400).json({
+      message: "Both startTime and duration are required",
+    });
+  }
+
 
   try {
     const session = await Session.findById(id);
@@ -46,6 +82,25 @@ export const rescheduleSession = async (req, res) => {
     if (!session) {
       return res.status(404).json({
         message: "Session not found",
+      });
+    }
+
+    const startDate = new Date(startTime);
+    const endDate = new Date(startDate.getTime() + duration * 60000);
+
+    const overlaps = await Session.find({
+      $or: [
+        { startTime: { $lt: startDate }, endTime: { $gt: startDate } },
+        { startTime: { $lt: endDate }, endTime: { $gt: endDate } },
+        { startTime: { $gt: startDate }, endTime: { $lt: endDate } }
+      ],
+      status: "scheduled",
+      _id: { $ne: id }
+    });
+
+    if (overlaps.length != 0) {
+      return res.status(400).json({
+        message: "The session's new schedule time is clashing with another session timing's.",
       });
     }
 

--- a/models/Session.js
+++ b/models/Session.js
@@ -15,11 +15,20 @@ const sessionSchema = new mongoose.Schema(
       ref: "User",
       required: true,
     },
+    sessionName: {
+      type: String,
+      required: true,
+    },
     status: {
       type: String,
       required: true,
       enum: ["scheduled", "completed", "cancelled"],
       default: "scheduled",
+    },
+    sessionType: {
+      type: String,
+      required: true,
+      default: "NA",
     },
     duration: {
       type: Number,  // duration in minutes

--- a/routes/sessionRoutes.js
+++ b/routes/sessionRoutes.js
@@ -3,7 +3,7 @@ import { createSession, rescheduleSession, cancelSession } from '../controllers/
 
 const router = express.Router();
 
-router.post('/create', createSession);
+router.post('/schedule', createSession);
 
 router.put('/reschedule/:id', rescheduleSession);
 


### PR DESCRIPTION
Issue: #17 

Set up a backend endpoint POST /api/sessions/schedule for booking sessions.
Validate requested time slots to ensure they are available and not conflicting with other user schedules.
Create logic to save session data in MongoDB with fields like userId, startTime, endTime, and sessionType.
