### PR TITLE
Added session availability logic

### DIFF
--- a/routes/sessionRoutes.js
+++ b/routes/sessionRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { createSession, rescheduleSession, cancelSession } from '../controllers/sessionController.js';
+import { createSession, rescheduleSession, cancelSession, getSessionAvailability } from '../controllers/sessionController.js';
 
 const router = express.Router();
 
@@ -8,5 +8,7 @@ router.post('/schedule', createSession);
 router.put('/reschedule/:id', rescheduleSession);
 
 router.delete('/delete/:id', cancelSession);
+
+router.get('/availability', getSessionAvailability);
 
 export default router;


### PR DESCRIPTION
Issue: #19 

Added the session availability logic.

Flow:

1. Created mock sessions.

![Screenshot (273)](https://github.com/user-attachments/assets/2cca9c96-498d-486e-9f18-4ac0c39f0bfb)
(9-10)

![Screenshot (274)](https://github.com/user-attachments/assets/8ac4e4e5-10ed-4218-aa66-e118e100ce66)
(11-12)

![Screenshot (275)](https://github.com/user-attachments/assets/dd84013c-a0bc-4cad-92ef-9c0133fe9551)
(13-14)

2. Result of request
(Start = 8, end = 15)
![Screenshot (272)](https://github.com/user-attachments/assets/f85f29f1-4156-44cb-9c82-4889beea10c8)

